### PR TITLE
feat: Integrate live product API from dummyjson.com

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/example/project/data/mapper/ProductMappers.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/data/mapper/ProductMappers.kt
@@ -1,0 +1,26 @@
+package org.example.project.data.mapper
+
+import org.example.project.data.remote.dto.DummyProductDto
+import org.example.project.model.Product
+import org.example.project.model.ProductDetails
+
+fun DummyProductDto.toProduct(): Product {
+    return Product(
+        id = this.id.toString(),
+        name = this.title,
+        shortDescription = this.description,
+        imageUrl = this.thumbnail ?: "", // Or a default placeholder image URL
+        price = this.price
+    )
+}
+
+fun DummyProductDto.toProductDetails(): ProductDetails {
+    return ProductDetails(
+        id = this.id.toString(),
+        name = this.title,
+        longDescription = this.description,
+        images = this.images ?: emptyList(),
+        price = this.price,
+        variants = this.tags ?: emptyList() // Using tags as variants as per DummyJSON structure
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/example/project/data/remote/dto/DummyProductDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/data/remote/dto/DummyProductDto.kt
@@ -1,0 +1,20 @@
+package org.example.project.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DummyProductDto(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val price: Double,
+    val thumbnail: String? = null,
+    val images: List<String>? = null,
+    val tags: List<String>? = null,
+    // Add other fields if they might be useful later, like:
+    // val category: String? = null,
+    // val brand: String? = null,
+    // val rating: Double? = null,
+    // val stock: Int? = null
+)

--- a/composeApp/src/commonMain/kotlin/org/example/project/data/remote/dto/DummyProductListDto.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/data/remote/dto/DummyProductListDto.kt
@@ -1,0 +1,11 @@
+package org.example.project.data.remote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DummyProductListDto(
+    val products: List<DummyProductDto>,
+    val total: Int,
+    val skip: Int,
+    val limit: Int
+)

--- a/composeApp/src/commonMain/kotlin/org/example/project/remote/KtorClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/remote/KtorClient.kt
@@ -1,0 +1,34 @@
+package org.example.project.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+fun createHttpClient(): HttpClient {
+    return HttpClient { // Ktor will pick the appropriate engine for each platform
+        install(ContentNegotiation) {
+            json(Json {
+                prettyPrint = true
+                isLenient = true
+                ignoreUnknownKeys = true // Very important for APIs that might add new fields
+            })
+        }
+        install(Logging) {
+            level = LogLevel.ALL // Log everything: INFO, HEADERS, BODY
+            logger = object : Logger {
+                override fun log(message: String) {
+                    println("Ktor HTTP Client: $message") // Simple println logger
+                }
+            }
+        }
+        // Default request configuration can be added here if needed
+        // install(DefaultRequest) { ... }
+    }
+}
+
+// You could also define it as a singleton if preferred, though a factory function is fine
+// val httpClient: HttpClient by lazy { createHttpClient() }

--- a/composeApp/src/commonMain/kotlin/org/example/project/remote/RemoteApiService.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/project/remote/RemoteApiService.kt
@@ -1,0 +1,41 @@
+package org.example.project.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import org.example.project.data.mapper.toProduct
+import org.example.project.data.mapper.toProductDetails
+import org.example.project.data.remote.dto.DummyProductDto
+import org.example.project.data.remote.dto.DummyProductListDto
+import org.example.project.model.Product
+import org.example.project.model.ProductDetails
+
+class RemoteApiService(private val httpClient: HttpClient) : ApiService {
+
+    private val baseUrl = "https://dummyjson.com"
+
+    override suspend fun getProducts(): List<Product> {
+        return try {
+            val response = httpClient.get("$baseUrl/products")
+            // Check if response is successful, though Ktor often throws exceptions for non-2xx
+            // For now, assume body() will throw if not successful or parse error
+            val productListDto = response.body<DummyProductListDto>()
+            productListDto.products.map { it.toProduct() }
+        } catch (e: Exception) {
+            // Log the error or handle it more gracefully
+            println("Error fetching products: ${e.message}")
+            emptyList() // Return empty list on error
+        }
+    }
+
+    override suspend fun getProductDetails(id: String): ProductDetails? {
+        return try {
+            val response = httpClient.get("$baseUrl/products/$id")
+            val productDto = response.body<DummyProductDto>()
+            productDto.toProductDetails()
+        } catch (e: Exception) {
+            println("Error fetching product details for id $id: ${e.message}")
+            null // Return null on error
+        }
+    }
+}


### PR DESCRIPTION
I've replaced the mock API service with a live API implementation using Ktor to fetch product data from https://dummyjson.com.

Key Changes:
- Added Data Transfer Objects (DTOs) `DummyProductDto` and `DummyProductListDto` to match the structure of the dummyjson.com API.
- Implemented mapper functions to convert DTOs to your app's domain models (`Product`, `ProductDetails`).
- Created `RemoteApiService` that uses a Ktor HttpClient to fetch data from:
    - `https://dummyjson.com/products` (for product list)
    - `https://dummyjson.com/products/{productID}` (for product details)
- Configured a shared Ktor `HttpClient` with content negotiation (Kotlinx JSON, ignoring unknown keys) and logging.
- Updated `ProductRepository` and ViewModel instantiations in `ProductListScreen` and `ProductDetailScreen` to use `RemoteApiService` with the configured Ktor client.
- Enhanced error handling in the UI:
    - Added "Retry" buttons to `ProductListScreen` and `ProductDetailScreen` when data fetching fails.

Your application now displays live data. I recommend manual testing across Android, iOS, and Web to ensure correct functionality and error handling with the live API.